### PR TITLE
Fix gitops intro showroom

### DIFF
--- a/content/modules/ROOT/examples/coolstore-gitops.yaml
+++ b/content/modules/ROOT/examples/coolstore-gitops.yaml
@@ -4,9 +4,9 @@ metadata:
   name: coolstore-app
 spec:
   destination:
-    namespace: user1-cicd
+    namespace: $USER-cicd
     name: in-cluster
-  project: user1
+  project: $USER
   source:
     path: content/modules/ROOT/files/module-01
     repoURL: https://github.com/AdvancedDevSecOpsWorkshop/workshop.git

--- a/content/modules/ROOT/examples/pipeline-helm-app-custom.yaml
+++ b/content/modules/ROOT/examples/pipeline-helm-app-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pipeline-helm-custom-values
 spec:
   destination:
-    namespace: user1-cicd
+    namespace: $USER-cicd
     name: in-cluster
   source:
     path: content/modules/ROOT/examples/globex-ui
@@ -14,7 +14,7 @@ spec:
       valueFiles:
         - custom_values_1/values.yaml
   sources: []
-  project: user1
+  project: $USER
   syncPolicy:
     automated:
       prune: true

--- a/content/modules/ROOT/examples/pipeline-helm-app-para.yaml
+++ b/content/modules/ROOT/examples/pipeline-helm-app-para.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pipeline-helm-params
 spec:
   destination:
-    namespace: user1-cicd
+    namespace: $USER-cicd
     name: in-cluster
   source:
     path: content/modules/ROOT/examples/globex-ui
@@ -17,7 +17,7 @@ spec:
         - name: sonarqube.hostUrl
           value: 'custom-sonar-host'
   sources: []
-  project: user1
+  project: $USER
   syncPolicy:
     automated:
       prune: true

--- a/content/modules/ROOT/examples/pipeline-helm-app.yaml
+++ b/content/modules/ROOT/examples/pipeline-helm-app.yaml
@@ -4,14 +4,14 @@ metadata:
   name: pipeline-helm
 spec:
   destination:
-    namespace: user1-cicd
+    namespace: $USER-cicd
     name: in-cluster
   source:
     path: content/modules/ROOT/examples/globex-ui
     repoURL: 'https://github.com/AdvancedDevSecOpsWorkshop/workshop.git'
     targetRevision: main
   sources: []
-  project: user1
+  project: $USER
   syncPolicy:
     automated:
       prune: true

--- a/content/modules/ROOT/files/gitops/helm/pipeline-helm-app-custom.yaml
+++ b/content/modules/ROOT/files/gitops/helm/pipeline-helm-app-custom.yaml
@@ -4,14 +4,14 @@ metadata:
   name: pipeline-helm
 spec:
   destination:
-    namespace: user1-cicd
+    namespace: ${USER}-cicd
     name: in-cluster
   source:
     path: globex-ui
     repoURL: 'https://github.com/jchraibi/helm-chart.git'
     targetRevision: main
   sources: []
-  project: user1
+  project: ${USER}
   syncPolicy:
     automated:
       prune: true

--- a/content/modules/ROOT/files/gitops/helm/pipeline-helm-app.yaml
+++ b/content/modules/ROOT/files/gitops/helm/pipeline-helm-app.yaml
@@ -4,14 +4,14 @@ metadata:
   name: pipeline-helm
 spec:
   destination:
-    namespace: user1-cicd
+    namespace: ${USER}-cicd
     name: in-cluster
   source:
     path: globex-ui
     repoURL: 'https://github.com/jchraibi/helm-chart.git'
     targetRevision: main
   sources: []
-  project: user1
+  project: ${USER}
   syncPolicy:
     automated:
       prune: true

--- a/content/modules/ROOT/pages/02-gitops-intro.adoc
+++ b/content/modules/ROOT/pages/02-gitops-intro.adoc
@@ -467,14 +467,12 @@ Now, apply the custom values file to the initial application using Argo CD:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc apply -f ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-custom.yaml -n {user}-argocd
+sed 's/$USER/{user}/' ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-custom.yaml | oc apply -f - -n {user}-argocd
 ----
 
 ==== Step 4: Verify the Changes
 
-
 Return to ArgoCD and click on "App Details," then navigate to the "Parameters" section, where you previously made changes. You’ll notice that the custom value file has been successfully added, and it has updated the values to display the animated balls in green.
-
 
 image::gitops-helm/custom-values.png[]
 
@@ -512,19 +510,16 @@ Apply this parameterised configuration to Argo CD:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc apply -f ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-para.yaml -n {user}-argocd
+sed 's/$USER/{user}/' ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-para.yaml | oc apply -f - -n {user}-argocd
 ----
 
 Return to the ArgoCD interface and navigate to the 'App Details' section. Click on 'Parameters.' You will notice that the custom values file, which was present in the previous example, has been successfully removed from the ArgoCD Application.
-
 
 image::gitops-helm/helm-parameters.png[]
 
 Deploying a Helm chart through ArgoCD with integrated parameters allows you to customise default settings without modifying the chart itself or relying on external values files. This centralises configuration management across different environments.
 
-
 ==== Step 4: Make Further Adjustments
-
 
 To make changes to the parameters, simply click on the 'Edit' button. Feel free to explore and make adjustments as desired during the workshop.
 

--- a/content/modules/ROOT/pages/02-gitops-intro.adoc
+++ b/content/modules/ROOT/pages/02-gitops-intro.adoc
@@ -310,7 +310,7 @@ Execute the following command to render the chart template from your local direc
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-helm template globex-ui ~/workshop/content/modules/ROOT/files/gitops/helm/globex-ui | sed 's/$USER/{user}/'
+helm template globex-ui ~/workshop/content/modules/ROOT/files/gitops/helm/globex-ui
 ----
 
 ==== Step 2: View the Output

--- a/content/modules/ROOT/pages/02-gitops-intro.adoc
+++ b/content/modules/ROOT/pages/02-gitops-intro.adoc
@@ -80,7 +80,7 @@ using the command below:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-sed 's/$USERNUM/%USERNUM%/' ~/workshop/content/modules/ROOT/files/gitops/coolstore-gitops.yaml | oc apply -n user%USERNUM%-argocd -f -
+sed 's/$USERNUM/{user}/' ~/workshop/content/modules/ROOT/files/gitops/coolstore-gitops.yaml | oc apply -n {user}-argocd -f -
 ----
 
 The newly created Application appears as a tile with the title `bgd-app` in the
@@ -99,7 +99,7 @@ resources were created:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc get all -n user%USERNUM%-cicd
+oc get all -n {user}-cicd
 ----
 
 The output should list several things:
@@ -134,12 +134,12 @@ Wait for the rollout of the new pods to happen in the deployment:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc rollout status deploy/inventory-quarkus -n user%USERNUM%-cicd
+oc rollout status deploy/inventory-quarkus -n {user}-cicd
 ----
 
 If it is successful, you can now visit the deployed application in the browser.
 
-From the OpenShift web console, select *user%USERNUM%-cicd* Project from
+From the OpenShift web console, select *{user}-cicd* Project from
 drop-down menu, and use the _Topology_ view to find the link as you did with
 the Argo CD console.
 
@@ -150,7 +150,7 @@ Alternatively, get the app Route from the CLI:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc get route gateway-vertx -n user%USERNUM%-cicd -o jsonpath='{"http://"}{.spec.host}{"\n"}'
+oc get route gateway-vertx -n {user}-cicd -o jsonpath='{"http://"}{.spec.host}{"\n"}'
 ----
 
 WARNING: This route is only available via HTTP. If you try to visit via HTTPS,
@@ -166,7 +166,7 @@ blue to green:
 [source,bash,subs="attributes+,+macros"]
 
 ----
-oc -n user%USERNUM%-cicd scale deploy inventory-quarkus --replicas=4
+oc -n {user}-cicd scale deploy inventory-quarkus --replicas=4
 ----
 
 You can see that the pods will start to get created, but instantly get deleted again. This is because OpenShift GitOps is automatically setting the replicas number to 1, as specified in the application manifest for the quarkus-inventory deployment.
@@ -201,7 +201,7 @@ Or, as in our case, after the fact by running the following command:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc patch application/coolstore-app -n user%USERNUM%-argocd --type=merge -p='{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
+oc patch application/coolstore-app -n {user}-argocd --type=merge -p='{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
 ----
 
 [#helm]
@@ -389,17 +389,17 @@ You should see the following output:
 include::ROOT:example$pipeline-helm-app.yaml[]
 ----
 
-This YAML configuration defines an Argo CD Application named "pipeline-helm" that deploys a Helm chart from a specific Git repository to the "user%USERNUM%-cicd" namespace.
+This YAML configuration defines an Argo CD Application named "pipeline-helm" that deploys a Helm chart from a specific Git repository to the "{user}-cicd" namespace.
 
 ==== Step 2: Deploy/Observe the Argo CD Application
 
 
-Apply the configuration in the file to create the Argo CD Application in the namespace user%USERNUM%-argocd. This application will deploy the Helm chart for the pipeline app:
+Apply the configuration in the file to create the Argo CD Application in the namespace {user}-argocd. This application will deploy the Helm chart for the pipeline app:
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc apply -f ~/workshop/content/modules/ROOT/files/gitops/helm/pipeline-helm-app.yaml -n user%USERNUM%-argocd
+oc apply -f ~/workshop/content/modules/ROOT/files/gitops/helm/pipeline-helm-app.yaml -n {user}-argocd
 ----
 
 In the ArgoCD interface you should see the successful deployment of the "pipeline-helm" application.
@@ -414,7 +414,7 @@ image::gitops-helm/pipeline-helm-app2.png[]
 
 Next, click on "Parameters." You will notice that there is no separate values file as the application is deployed directly from the Helm chart.
 
-All the files are now deployed in the user%USERNUM%-cicd namespace, and you can see the full pipeline by accessing Pipelines -> pipelines in the console, as shown below:
+All the files are now deployed in the {user}-cicd namespace, and you can see the full pipeline by accessing Pipelines -> pipelines in the console, as shown below:
 
 image::gitops-helm/pipeline-view.png[]
 
@@ -467,7 +467,7 @@ Now, apply the custom values file to the initial application using Argo CD:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc apply -f ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-custom.yaml -n user%USERNUM%-argocd
+oc apply -f ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-custom.yaml -n {user}-argocd
 ----
 
 ==== Step 4: Verify the Changes
@@ -512,7 +512,7 @@ Apply this parameterised configuration to Argo CD:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc apply -f ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-para.yaml -n user%USERNUM%-argocd
+oc apply -f ~/workshop/content/modules/ROOT/examples/pipeline-helm-app-para.yaml -n {user}-argocd
 ----
 
 Return to the ArgoCD interface and navigate to the 'App Details' section. Click on 'Parameters.' You will notice that the custom values file, which was present in the previous example, has been successfully removed from the ArgoCD Application.

--- a/content/modules/ROOT/pages/02-gitops-intro.adoc
+++ b/content/modules/ROOT/pages/02-gitops-intro.adoc
@@ -80,7 +80,7 @@ using the command below:
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-sed 's/$USERNUM/{user}/' ~/workshop/content/modules/ROOT/files/gitops/coolstore-gitops.yaml | oc apply -n {user}-argocd -f -
+sed 's/$USER/{user}/' ~/workshop/content/modules/ROOT/files/gitops/coolstore-gitops.yaml | oc apply -n {user}-argocd -f -
 ----
 
 The newly created Application appears as a tile with the title `bgd-app` in the

--- a/content/modules/ROOT/pages/02-gitops-intro.adoc
+++ b/content/modules/ROOT/pages/02-gitops-intro.adoc
@@ -310,7 +310,7 @@ Execute the following command to render the chart template from your local direc
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-helm template globex-ui ~/workshop/content/modules/ROOT/files/gitops/helm/globex-ui
+helm template globex-ui ~/workshop/content/modules/ROOT/files/gitops/helm/globex-ui | sed 's/$USER/{user}/'
 ----
 
 ==== Step 2: View the Output
@@ -399,7 +399,7 @@ Apply the configuration in the file to create the Argo CD Application in the nam
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-oc apply -f ~/workshop/content/modules/ROOT/files/gitops/helm/pipeline-helm-app.yaml -n {user}-argocd
+sed 's/$USER/{user}/' ~/workshop/content/modules/ROOT/files/gitops/helm/pipeline-helm-app.yaml |  oc apply -f - -n {user}-argocd
 ----
 
 In the ArgoCD interface you should see the successful deployment of the "pipeline-helm" application.


### PR DESCRIPTION
Fixed the user parameterization for Showroom and corrected the hardcoded user1 in some of the files.

There are a few other issues I noted as follows, if you want me to work on them just let me know:

- The configuration drift section is hard to follow since the application has selfHeal enabled by default. In the original GitOps workshop it was disabled and then renabled by the patch command in the workshop. 
- Pipeline application is out of sync, needs IgnoreDifferences added to it
- Helm from original GitOps workshop talks abput custom values and parameters with demos but AFAIK none of these are actually used here, should we tighten these up and remove them? A basic helm example is probably sufficient for this workshop?
